### PR TITLE
Add unit tests and PR CI; extract testable game logic into game_logic.py

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,28 @@
+name: PR Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,0 +1,52 @@
+"""Pure game logic helpers that can be tested without Ursina runtime."""
+
+from typing import Any, Mapping
+
+
+BLOCK_PICK_KEYS = {
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9,
+    '0': 0,
+}
+
+BLOCK_PICK_TEXTURES = {
+    1: 'grass',
+    2: 'stone',
+    3: 'brick',
+    4: 'dirt',
+    5: 'cobble',
+    6: 'spruce',
+    7: 'planks',
+    8: 'dirt',
+    9: 'brick',
+    0: 'image',
+}
+
+
+def selected_block_pick(held_keys: Mapping[str, Any], current_pick: int) -> int:
+    """Return the active block pick based on numeric key presses."""
+    for key, value in BLOCK_PICK_KEYS.items():
+        if held_keys.get(key):
+            return value
+    return current_pick
+
+
+def movement_settings(held_keys: Mapping[str, Any]) -> tuple[int, int]:
+    """Return (player_speed, camera_fov) based on movement modifiers."""
+    if held_keys.get('left control'):
+        return 15, 107
+    if held_keys.get('left shift'):
+        return 5, 92
+    return 8, 100
+
+
+def texture_name_for_pick(block_pick: int) -> str:
+    """Return the symbolic texture name for a given block selection."""
+    return BLOCK_PICK_TEXTURES[block_pick]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from ursina import *
 from ursina.prefabs.first_person_controller import FirstPersonController
 from numba import jit
+from game_logic import movement_settings, selected_block_pick, texture_name_for_pick
 
 app = Ursina()
 
@@ -49,37 +50,8 @@ def update():
     global block_pick
     global hand
 
-    if held_keys['1']:
-        block_pick = 1
-    if held_keys['2']:
-        block_pick = 2
-    if held_keys['3']:
-        block_pick = 3
-    if held_keys['4']:
-        block_pick = 4
-    if held_keys['5']:
-        block_pick = 5
-    if held_keys['6']:
-        block_pick = 6
-    if held_keys['7']:
-        block_pick = 7
-    if held_keys['8']:
-        block_pick = 8
-    if held_keys['9']:
-        block_pick = 9
-    if held_keys['0']:
-        block_pick = 0
-
-    if held_keys['left control']:
-        player.speed = 15
-        camera.fov = 107
-
-    elif held_keys['left shift']:
-        player.speed = 5
-        camera.fov = 92
-    else:
-        player.speed = 8
-        camera.fov = 100
+    block_pick = selected_block_pick(held_keys, block_pick)
+    player.speed, camera.fov = movement_settings(held_keys)
 
 
 # setting up the hand
@@ -113,26 +85,18 @@ class Voxel(Button):
     def input(self, key):
         if self.hovered:
             if key == 'right mouse down':
-                if block_pick == 1:
-                    Voxel(position=self.position + mouse.normal, texture=grass_texture)
-                if block_pick == 2:
-                    Voxel(position=self.position + mouse.normal, texture=stone_texture)
-                if block_pick == 3:
-                    Voxel(position=self.position + mouse.normal, texture=brick_texture)
-                if block_pick == 4:
-                    Voxel(position=self.position + mouse.normal, texture=dirt_texture)
-                if block_pick == 5:
-                    Voxel(position=self.position + mouse.normal, texture=cobble_texture)
-                if block_pick == 6:
-                    Voxel(position=self.position + mouse.normal, texture=spruce_texture)
-                if block_pick == 7:
-                    Voxel(position=self.position + mouse.normal, texture=planks_texture)
-                if block_pick == 8:
-                    Voxel(position=self.position + mouse.normal, texture=dirt_texture)
-                if block_pick == 9:
-                    Voxel(position=self.position + mouse.normal, texture=brick_texture)
-                if block_pick == 0:
-                    Voxel(position=self.position + mouse.normal, texture=image)
+                texture_name = texture_name_for_pick(block_pick)
+                textures = {
+                    'grass': grass_texture,
+                    'stone': stone_texture,
+                    'brick': brick_texture,
+                    'dirt': dirt_texture,
+                    'cobble': cobble_texture,
+                    'spruce': spruce_texture,
+                    'planks': planks_texture,
+                    'image': image,
+                }
+                Voxel(position=self.position + mouse.normal, texture=textures[texture_name])
 
             if key == 'left mouse down':
                 destroy(self)
@@ -173,4 +137,7 @@ def input(key):
 
 player = FirstPersonController()
 sky = Sky()
-app.run()
+
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -1,0 +1,27 @@
+from game_logic import movement_settings, selected_block_pick, texture_name_for_pick
+
+
+def test_selected_block_pick_defaults_to_current_when_no_numeric_key_pressed():
+    held_keys = {'left control': True}
+    assert selected_block_pick(held_keys, current_pick=4) == 4
+
+
+def test_selected_block_pick_updates_on_numeric_key_press():
+    held_keys = {'3': True}
+    assert selected_block_pick(held_keys, current_pick=1) == 3
+
+
+def test_movement_settings_prioritizes_sprint_over_crouch():
+    held_keys = {'left control': True, 'left shift': True}
+    assert movement_settings(held_keys) == (15, 107)
+
+
+def test_movement_settings_crouch_values():
+    held_keys = {'left shift': True}
+    assert movement_settings(held_keys) == (5, 92)
+
+
+def test_texture_name_for_pick_mappings():
+    assert texture_name_for_pick(1) == 'grass'
+    assert texture_name_for_pick(8) == 'dirt'
+    assert texture_name_for_pick(0) == 'image'


### PR DESCRIPTION
### Motivation

- Make core block-selection and movement behavior testable without launching the Ursina runtime by isolating pure logic. 
- Provide automated checks on pull requests so regressions are caught early in CI.

### Description

- Extracted block-selection, movement modifier logic, and texture mapping into a new `game_logic.py` module and exposed `selected_block_pick`, `movement_settings`, and `texture_name_for_pick` helpers. 
- Updated `main.py` to call the new helpers in `update()` and voxel placement handling, and added an `if __name__ == '__main__'` guard to avoid starting the app on import. 
- Added unit tests in `tests/test_game_logic.py` that cover numeric selection, movement priority/values, and texture mapping. 
- Added `tests/conftest.py` to insert the project root on `sys.path` and created a GitHub Actions workflow `.github/workflows/pr-checks.yml` that runs `pytest` on pull requests and pushes to `main` using Python `3.11`.

### Testing

- Ran `pytest -q` locally and all tests passed (`5 passed`).
- Added CI workflow to run the same test suite on PRs and pushes to `main` (will run `pytest -q` under `actions/setup-python@v5` with `python-version: '3.11'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24996e6b8832a9d2f02d7bcf67762)