### PR TITLE
Use uv for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -43,8 +43,25 @@ PR's open, feel free to contribute
 ________________________________________________________________________
 
 # Installation
-https://www.ursinaengine.org/installation.html
 
-Follow this installer and also add the optional ursina extras packages, then simply run the main.py file and enjoy
+This project uses the [Astral uv](https://docs.astral.sh/uv/) package manager.
 
-Written in python 3.10
+Install dependencies with uv:
+
+```bash
+uv sync
+```
+
+Run the game:
+
+```bash
+uv run python main.py
+```
+
+Run the tests:
+
+```bash
+uv run pytest
+```
+
+Written in Python 3.10+.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from ursina import *
 from ursina.prefabs.first_person_controller import FirstPersonController
-from numba import jit
 from game_logic import movement_settings, selected_block_pick, texture_name_for_pick
 
 app = Ursina()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "voxel-jpg-py"
+version = "0.0.3"
+description = "Very basic Minecraft-inspired voxel game made in Python using the Ursina game engine."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "ursina",
+]
+
+[dependency-groups]
+dev = [
+    "pytest",
+]
+
+[tool.uv]
+package = false


### PR DESCRIPTION
### Motivation
- Move the project to Astral uv for dependency management and avoid pinned versions by declaring unpinned dependencies in `pyproject.toml`.
- Simplify setup and test instructions to use `uv` workflows that are reproducible for users familiar with the tool.
- Remove an unused imported dependency to avoid implying a requirement that is not used at runtime.

### Description
- Add `pyproject.toml` with unpinned runtime dependency `ursina` and dev dependency `pytest`, and `[tool.uv] package = false` to enable `uv` usage.
- Update `README.md` installation and usage instructions to use `uv` commands: `uv sync`, `uv run python main.py`, and `uv run pytest`.
- Remove the unused `numba` import from `main.py` to avoid requiring an irrelevant dependency.
- Add `.gitignore` entries for `__pycache__/`, `*.py[cod]`, `.venv/`, and `.pytest_cache/` to ignore common local artifacts.

### Testing
- Ran `pytest -q` which completed successfully (`5 passed`).
- Ran `python -m compileall -q main.py game_logic.py tests` which succeeded without errors.
- Attempted `uv run pytest -q` but it was blocked by PyPI network tunnel errors in this environment and did not complete.
- Attempted `uv lock` but it was blocked by PyPI network tunnel errors in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42bca0cd88832a87e6aa9fa1c25202)